### PR TITLE
Add qa/test-resources.md page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -36,7 +36,9 @@
   * Shared Libraries
       * [Pattern Lab](frontend/pattern-lab.md)
       * [React Storybook](frontend/storybook.md)
-* [QA](qa/manualQA.md)
+* QA
+  * [Manual QA](qa/manualQA.md)
+  * [Test Resources](qa/test-resources.md)
 
 ## Team
 

--- a/qa/test-resources.md
+++ b/qa/test-resources.md
@@ -1,0 +1,13 @@
+# Test Resources
+
+While performing tests, both manual and automated, we need resources to emulate realistic scenarios. This page aims to be a repository of references of those resources.
+
+## Test Credit Cards
+
+Test credit cards are to be used in user journeys that require payments / donation. Donations and Prize Platform are examples of such workflows. We can use the test credit cards to validate the workflow, assuring the user journey completes successfuly, and to test how the backend services process the payment event.
+
+### World Pay
+
+World Pay supplies a test credit cards page allowing us to simulate most credit card vendors:
+
+https://developer.worldpay.com/docs/wpg/reference/testvalues#test-card-numbers

--- a/qa/test-resources.md
+++ b/qa/test-resources.md
@@ -11,3 +11,23 @@ Test credit cards are to be used in user journeys that require payments / donati
 World Pay supplies a test credit cards page allowing us to simulate most credit card vendors:
 
 https://developer.worldpay.com/docs/wpg/reference/testvalues#test-card-numbers
+
+### Braintree
+
+Braintree test credit cards page 
+
+https://developers.braintreepayments.com/guides/credit-cards/testing-go-live/php
+
+### Stripe
+
+Stripe test card numbers page
+
+https://stripe.com/docs/testing
+
+### Paypal
+
+Paypal test account 
+
+email: paypal_sponsorship-buyer@comicrelief.com
+
+password: frostuser

--- a/qa/test-resources.md
+++ b/qa/test-resources.md
@@ -26,7 +26,7 @@ https://stripe.com/docs/testing
 
 ### Paypal
 
-Paypal test account 
+Paypal sandbox account 
 
 email: paypal_sponsorship-buyer@comicrelief.com
 

--- a/qa/test-resources.md
+++ b/qa/test-resources.md
@@ -26,8 +26,7 @@ https://stripe.com/docs/testing
 
 ### Paypal
 
-Paypal sandbox account 
+For paypal sandbox account details see below:
 
-email: paypal_sponsorship-buyer@comicrelief.com
+https://github.com/comicrelief/react-donation/blob/889e2a4fc34795e3136a705f2f5d49ec42ee76e6/tests/commands/paypal.js#L5
 
-password: frostuser


### PR DESCRIPTION
The `qa/test-resources.md` page will list resources used for manual and
automated qa, such as test credit cards, so that we always know what
resources to use to simulate a user journey.